### PR TITLE
Remove unused CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Change Log
-
-All notable changes to the "barbenheimer" extension will be documented in this file.
-
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
-
-## [Unreleased]
-
-- Initial release


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the `CHANGELOG.md` file, which documented notable changes to the "barbenheimer" extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->