### PR TITLE
Update README copy for theme overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Barbenheimer VS Code Theme
 
-Barbenheimer is a VS Code theme suite inspired by the contrast between Barbie's playful color world and Oppenheimer's stark cinematic intensity. It includes one bright light theme and two dark themes, each tuned for readable editor text, clear buttons and badges, focused UI states, and expressive syntax color.
+This VS Code theme draws inspiration from the cultural phenomenon "Barbenheimer," which arose from the coinciding release dates of Greta Gerwig's Barbie and Christopher Nolan's Oppenheimer. It playfully blends the vibrant and colorful world of Barbie with the stark and intense imagery of Oppenheimer, resulting in a unique coding experience.
+
+The theme offers three distinct variants, each capturing a different facet of the Barbenheimer concept. Whether you prefer the bright cheerfulness of Barbie's world or the somber atmosphere of Oppenheimer's, there's a style to fit your coding mood and personalize your VS Code environment.
 
 ## Installation
 
@@ -17,7 +19,7 @@ Barbenheimer is a VS Code theme suite inspired by the contrast between Barbie's 
 
 Dreamhouse is the bright, girly, Barbie-forward variant. It uses a blush pink editor surface, saturated pink icons, sky-blue buttons and badges, purple links and syntax accents, and dark plum text for strong contrast.
 
-**Current palette**
+**Color Palette**
 
 | Color            | Hex Code  | Role                                              |
 | ---------------- | --------- | ------------------------------------------------- |
@@ -38,7 +40,7 @@ Dreamhouse is the bright, girly, Barbie-forward variant. It uses a blush pink ed
 
 Bunker is the moody dark theme. It keeps the Oppenheimer side grounded with black-olive backgrounds, restrained borders, pink active states, and purple primary buttons.
 
-**Current palette**
+**Color Palette**
 
 | Color              | Hex Code    | Role                                       |
 | ------------------ | ----------- | ------------------------------------------ |
@@ -57,7 +59,7 @@ Bunker is the moody dark theme. It keeps the Oppenheimer side grounded with blac
 
 Nuclear Sunrise is the highest-contrast dark theme. It uses near-black backgrounds, white editor text, hot pink accents, a clear dark surface ladder, and purple primary buttons.
 
-**Current palette**
+**Color Palette**
 
 | Color              | Hex Code    | Role                                         |
 | ------------------ | ----------- | -------------------------------------------- |
@@ -73,55 +75,14 @@ Nuclear Sunrise is the highest-contrast dark theme. It uses near-black backgroun
 
 ![Barbenheimer Nuclear Sunrise](images/barbenheimer-nuclear-sunrise.png)
 
-## Accessibility And Contrast
-
-The current themes are tuned around readable UI surfaces and syntax tokens:
-
-- Dreamhouse uses dark plum text on blush surfaces and sky-blue controls with dark text for high-contrast buttons and badges.
-- Bunker and Nuclear Sunrise use light text on dark surfaces, with pink active states and softened structural borders.
-- Numeric badges, primary buttons, extension buttons, activity icons, editor icons, and TS/TSX token colors have been checked for contrast in the current palettes.
-
-Visual assets and screenshots may lag behind theme JSON changes. Relaunch the Extension Development Host and capture new previews after major color updates.
-
-## Development
-
-Install dependencies:
-
-```sh
-npm install
-```
-
-Launch the extension in VS Code:
-
-```sh
-code --extensionDevelopmentPath=$(pwd)
-```
-
-Package locally:
-
-```sh
-npx vsce package
-```
-
-Before publishing, test all three themes in the Extension Development Host and inspect representative files such as TypeScript, TSX, Markdown, JSON, and terminal output.
-
-## Recommended Verification
-
-- Cycle through all three variants in **Preferences: Color Theme**.
-- Open a TSX file and confirm Dreamhouse token separation across imports, JSX tags, attributes, functions, constants, variables, and punctuation.
-- Confirm Activity Bar and editor icons are pink in Dreamhouse where VS Code color tokens control them.
-- Confirm numeric badges and buttons are sky blue in Dreamhouse.
-- Confirm Bunker and Nuclear Sunrise buttons remain readable.
-- Run JSON validation or parse all theme files before committing.
-
 ## Fonts
 
-The screenshots use [Dank Mono](https://dank.sh/). [Fira Code](https://github.com/tonsky/FiraCode) is a free alternative that works well with the theme.
+I am using a paid font titled [Dank Mono](https://dank.sh/). [Fira Code](https://github.com/tonsky/FiraCode) is a free one that works well too.
 
 ## Feedback
 
-Open an issue or pull request at [jayvicsanantonio/barbenheimer-vscode-theme](https://github.com/jayvicsanantonio/barbenheimer-vscode-theme) with contrast notes, token-scope feedback, or preview screenshots.
+If you have any feedback or suggestions, please [open an issue](https://github.com/jpsanantonio/barbenheimer-vscode-theme/issues) or better yet, a [pull request](https://github.com/jpsanantonio/barbenheimer-vscode-theme/pulls). I would love to hear from you!
 
 ## License
 
-Barbenheimer is licensed under the MIT License. See [LICENSE](LICENSE.md) for details.
+Barbenheimer is licensed under the MIT License. See [LICENSE](LICENSE.md) for more details.


### PR DESCRIPTION
## Summary
- Refresh the README introduction with clearer Barbenheimer context and variant overview
- Standardize palette section headings across all three theme descriptions
- Reword font, feedback, and license copy for a more polished tone
- Remove outdated development and verification notes from the README