### PR TITLE
chore: update repository links in README and bump version to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ I am using a paid font titled [Dank Mono](https://dank.sh/). [Fira Code](https:/
 
 ## Feedback
 
-If you have any feedback or suggestions, please [open an issue](https://github.com/jpsanantonio/barbenheimer-vscode-theme/issues) or better yet, a [pull request](https://github.com/jpsanantonio/barbenheimer-vscode-theme/pulls). I would love to hear from you!
+If you have any feedback or suggestions, please [open an issue](https://github.com/jayvicsanantonio/barbenheimer-vscode-theme/issues) or better yet, a [pull request](https://github.com/jayvicsanantonio/barbenheimer-vscode-theme/pulls). I would love to hear from you!
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Barbenheimer",
   "description": "Barbenheimer is a VS Code theme inspired by the Internet phenomenon of the same name. It combines the pink and playful aesthetics of Barbie with the dark and dramatic tones of Oppenheimer.",
   "icon": "images/barbenheimer-icon.png",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the repository links in README and bump version to 1.1.1
